### PR TITLE
[#154769249] Upgrade runtime to python-3.6.4

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.6.4


### PR DESCRIPTION
What?
----

python-3.6.2 is not supported by the new buildpack upgraded in
alphagov/paas-cf#1238

How to review
--------

 - Code review, I am testing in my env
 - After merge:
   - tag the commit 
   - upgrade the tag id in https://github.com/alphagov/paas-cf/blob/690b40e640fc6b7a8e753cb89c48600e8dcd5843/concourse/pipelines/create-cloudfoundry.yml#L276-L277 for the PR alphagov/paas-cf#1238


Who?
---

Anyone but @keymon