### PR TITLE
[#154769249] Request runtime as latest version of python 3.6

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.4
+python-3.6.x


### PR DESCRIPTION
What?
----

There is no reason to pin to a specific version and would
prevent issues when upgrading the buildpack as it happened
with alphagov/paas-cf#1238

How to review?
-------------

Code review. I tested in my environment.

After merge, tag as v0.1.2

Who?
---

not me